### PR TITLE
Foyer tutorial mods

### DIFF
--- a/tutorials/Foyer-tutorial.ipynb
+++ b/tutorials/Foyer-tutorial.ipynb
@@ -351,32 +351,7 @@
    "source": [
     "### GMSO enabled Foyer\n",
     "\n",
-    "Foyer has been undergoing development to support GMSO. Interaction with foyer is very similar to the prior example,  where we load in a forcefield and pass the mbuild compound to the apply function of the forcefield to perform atom typing.  The apply function returns here a GMSO topology, rather than a ParmEd topology, and thus for the GMSO topology, the save command provides us with access to file writers for all the supported engines.  "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from foyer import general_forcefield\n",
-    "\n",
-    "opls_alkane_gmso = general_forcefield.Forcefield(forcefield_files='xml_files/oplsaa_alkanes.xml', strict=False)\n",
-    "\n",
-    "typed_gmso = opls_alkane_gmso.apply(compound, assert_improper_params=False, \n",
-    "                                    assert_dihedral_params=False, debug=False)\n",
-    "\n",
-    "typed_gmso.save('test3.top', overwrite=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!cat test3.top"
+    "Foyer has been undergoing development to support GMSO. Interaction with foyer is very similar to the prior example,  where we load in a Foyer forcefield into GMSO. This can be applied to a structure very similarly, using the `gmso.parameterization` suite of tools. This also allows you to load individual forcefields and apply the to seperate substructures of the topology. See the tutorial labeled **tutorials/GMSO-tutorial.ipynb** for more information."
    ]
   },
   {

--- a/tutorials/GMSO-tutorial.ipynb
+++ b/tutorials/GMSO-tutorial.ipynb
@@ -379,7 +379,7 @@
     "from gmso.tests.utils import get_path\n",
     "tip3p_ff = ForceField(get_path('tip3p.xml'))\n",
     "tip3p_ff.atom_types[atype.name] = atype\n",
-    "#tip3p_ff.xml(\"gmso_files/tip3p_modified.xml\") #Waiting on PR #541\n"
+    "tip3p_ff.xml(\"gmso_files/tip3p_modified.xml\") \n"
    ]
   },
   {


### PR DESCRIPTION
* Change the name of the Foyer tutorials
* Since the Foyer General_ForceField class has not been debugged to work with the develop branch of the GMSO topology, this has been removed from the Foyer tutorial.
    - See [issue # 510 in Foyer](https://github.com/mosdef-hub/foyer/issues/510) 
    - The General Forcefield will soon be deprecated for the GMSO ForceField.
